### PR TITLE
feature: load all project files and parse ast for go_search

### DIFF
--- a/gopls/internal/cache/llm_bridge.go
+++ b/gopls/internal/cache/llm_bridge.go
@@ -1,0 +1,40 @@
+package cache
+
+import (
+	"context"
+	"go/parser"
+	"go/token"
+
+	"golang.org/x/tools/gopls/internal/cache/parsego"
+	"golang.org/x/tools/gopls/internal/file"
+)
+
+// ParseGoImpl is an exported version of the internal parseGoImpl function.
+//
+// This function is provided for external tools (such as LLM/MCP bridges) that need
+// to parse Go source files WITHOUT using the parseCache. This is useful for
+// one-time operations like symbol search, where:
+//   - Files are parsed once for immediate analysis
+//   - Parse results are not cached
+//   - Memory is reclaimed immediately after use
+//
+// The parseCache is optimized for repeated access to the same files during
+// active editing. For batch operations on many files, bypassing the cache
+// avoids unnecessary memory accumulation.
+//
+// Usage Example:
+//
+//	fset := token.NewFileSet()
+//	pgf, err := cache.ParseGoImpl(ctx, fset, fh, parser.ParseComments, false)
+//	if err != nil {
+//	    return err
+//	}
+//	// Extract symbols from pgf...
+//	// pgf is eligible for GC when it goes out of scope
+//
+// This wrapper exists to avoid modifying the internal parseGoImpl function.
+// When cherry-picking changes from upstream gopls, this file should be
+// reviewed but typically will not need changes.
+func ParseGoImpl(ctx context.Context, fset *token.FileSet, fh file.Handle, mode parser.Mode, purgeFuncBodies bool) (*parsego.File, error) {
+	return parseGoImpl(ctx, fset, fh, mode, purgeFuncBodies)
+}

--- a/gopls/mcpbridge/test/e2e/e2e_all_tools_test.go
+++ b/gopls/mcpbridge/test/e2e/e2e_all_tools_test.go
@@ -145,6 +145,7 @@ func TestAllTools(t *testing.T) {
 			args: map[string]any{
 				"query":       "Handler",
 				"max_results": 5,
+				"Cwd":         globalGoplsMcpDir,
 			},
 			assertion: func(t *testing.T, content string) {
 				if !strings.Contains(content, "Handler") {

--- a/gopls/mcpbridge/test/e2e/e2e_comprehensive_workflows_test.go
+++ b/gopls/mcpbridge/test/e2e/e2e_comprehensive_workflows_test.go
@@ -143,6 +143,7 @@ func TestRealWorkflow_ToolChain_ChainingMultipleTools(t *testing.T) {
 			Arguments: map[string]any{
 				"query":       "handleGoDefinition",
 				"max_results": 5,
+				"Cwd":         globalGoplsMcpDir,
 			},
 		})
 		if err != nil {

--- a/gopls/mcpbridge/test/e2e/e2e_real_test_files_test.go
+++ b/gopls/mcpbridge/test/e2e/e2e_real_test_files_test.go
@@ -261,6 +261,7 @@ func TestRealTestFiles_FindTestUsages(t *testing.T) {
 			Arguments: map[string]any{
 				"query":       "globalSession",
 				"max_results": 10,
+				"Cwd":         globalGoplsMcpDir,
 			},
 		})
 		if err != nil {

--- a/gopls/mcpbridge/test/e2e/e2e_refactoring_test.go
+++ b/gopls/mcpbridge/test/e2e/e2e_refactoring_test.go
@@ -161,6 +161,7 @@ func TestRefactoring_ExtractFunction(t *testing.T) {
 			Arguments: map[string]any{
 				"query":       "handleGoDefinition",
 				"max_results": 3,
+				"Cwd":         globalGoplsMcpDir,
 			},
 		})
 		if err != nil {
@@ -272,6 +273,7 @@ func TestRefactoring_InlineFunction(t *testing.T) {
 			Arguments: map[string]any{
 				"query":       "ResultText",
 				"max_results": 5,
+				"Cwd":         globalGoplsMcpDir,
 			},
 		})
 		if err != nil {

--- a/gopls/mcpbridge/test/integration/integration_go_search_test.go
+++ b/gopls/mcpbridge/test/integration/integration_go_search_test.go
@@ -114,7 +114,7 @@ func TestGoSearchE2E(t *testing.T) {
 		"CommonKeywords": {
 			tool: "go_search",
 			args: map[string]any{
-				"query": "func",
+				"query": "Hello", // Search for actual symbol in simple project
 			},
 			assertions: []assertion{
 				assertContains("Found"), // Should find results


### PR DESCRIPTION
Previously, gopls-mcp highly relies on gopls view and snapshot mechansim to tackle the project symbol search, but it's contradict with the design of snapshot lazily initializaiton.

This commit changes the direction to parse ast directly for all files, as the AST for symbol search is sufficient.

Besides, ast parsing is quite fast and cheap. It parses file at single ms level.

	src/crypto/internal/fips140/asan.go 1.694035ms
	src/cmd/gofmt/gofmt.go 2.19699ms
	src/cmd/go/internal/work/build.go 2.640626ms

Fixes #4