### PR TITLE
feat: lazy init gopls session with idle timeout

### DIFF
--- a/gopls/internal/filewatcher/filewatcher_test.go
+++ b/gopls/internal/filewatcher/filewatcher_test.go
@@ -510,7 +510,7 @@ func TestSkipDirFunc(t *testing.T) {
 		return filepath.Base(dirPath) == "ignored"
 	}
 
-	w, err := filewatcher.New(50*time.Millisecond, nil, eventsHandler, errHandler, filewatcher.WithSkipDir(skipDirFunc))
+	w, err := filewatcher.New(settings.FileWatcherFSNotify, nil, eventsHandler, errHandler, filewatcher.WithSkipDir(skipDirFunc))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/gopls/mcpbridge/core/config.go
+++ b/gopls/mcpbridge/core/config.go
@@ -34,6 +34,12 @@ type MCPConfig struct {
 	// Default: 32000 (32KB)
 	// JSON field name: max_response_bytes
 	MaxResponseBytes int `json:"max_response_bytes,omitempty"`
+
+	// IdleTimeout is the duration of inactivity before gopls session resources
+	// are released. Accepts Go duration strings: "5m", "30s", "500ms".
+	// On next tool call the session is re-initialized automatically.
+	// Default: "5m".
+	IdleTimeout string `json:"idle_timeout,omitempty"`
 }
 
 // DefaultConfig returns a default configuration.
@@ -41,6 +47,7 @@ func DefaultConfig() *MCPConfig {
 	return &MCPConfig{
 		Gopls:            make(map[string]any),
 		MaxResponseBytes: 32000, // 32KB
+		IdleTimeout:      "5m",
 	}
 }
 
@@ -62,6 +69,9 @@ func LoadConfig(data []byte) (*MCPConfig, error) {
 	}
 	if config.MaxResponseBytes == 0 {
 		config.MaxResponseBytes = 32000 // 32KB
+	}
+	if config.IdleTimeout == "" {
+		config.IdleTimeout = "5m"
 	}
 
 	return &config, nil

--- a/gopls/mcpbridge/core/handler_lifecycle_test.go
+++ b/gopls/mcpbridge/core/handler_lifecycle_test.go
@@ -1,0 +1,215 @@
+package core
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/tools/gopls/internal/cache"
+)
+
+// mockCloser tracks Close() calls for testing.
+type mockCloser struct {
+	closed atomic.Bool
+}
+
+func (m *mockCloser) Close() error {
+	m.closed.Store(true)
+	return nil
+}
+
+// newTestHandler creates a Handler with a mock initFn that returns a real (empty)
+// cache.Session and a mock file watcher. The idle timeout is set via idleTimeout
+// directly so tests can use sub-second values.
+func newTestHandler(t *testing.T, idleTimeout time.Duration) (*Handler, *mockCloser, *atomic.Int32) {
+	t.Helper()
+
+	watcher := &mockCloser{}
+	var initCount atomic.Int32
+
+	initFn := func(ctx context.Context) (*cache.Session, Symbler, io.Closer, error) {
+		initCount.Add(1)
+		// A real empty session: no views, no disk access, cheap to create.
+		s := cache.NewSession(ctx, cache.New(nil))
+		return s, nil, watcher, nil
+	}
+
+	h := NewHandler(initFn, WithConfig(DefaultConfig()))
+	h.idleTimeout = idleTimeout
+	return h, watcher, &initCount
+}
+
+func TestHandler_LazyInit(t *testing.T) {
+	h, _, initCount := newTestHandler(t, time.Minute)
+
+	// Session must be nil before first tool call.
+	h.initMu.Lock()
+	if h.session != nil {
+		t.Error("session should be nil before first ensureSession call")
+	}
+	h.initMu.Unlock()
+
+	// First call initializes.
+	if err := h.ensureSession(context.Background()); err != nil {
+		t.Fatalf("ensureSession failed: %v", err)
+	}
+
+	h.initMu.Lock()
+	if h.session == nil {
+		t.Error("session should be non-nil after ensureSession")
+	}
+	h.initMu.Unlock()
+
+	if got := initCount.Load(); got != 1 {
+		t.Errorf("initFn called %d times, want 1", got)
+	}
+
+	// Subsequent calls must not reinitialize.
+	for i := 0; i < 5; i++ {
+		if err := h.ensureSession(context.Background()); err != nil {
+			t.Fatalf("ensureSession[%d] failed: %v", i, err)
+		}
+	}
+	if got := initCount.Load(); got != 1 {
+		t.Errorf("initFn called %d times after repeated ensureSession, want 1", got)
+	}
+}
+
+func TestHandler_ConcurrentEnsureSession(t *testing.T) {
+	h, _, initCount := newTestHandler(t, time.Minute)
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if err := h.ensureSession(context.Background()); err != nil {
+				t.Errorf("concurrent ensureSession failed: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// initFn must be called exactly once despite concurrent callers.
+	if got := initCount.Load(); got != 1 {
+		t.Errorf("initFn called %d times with %d concurrent callers, want 1", got, goroutines)
+	}
+}
+
+func TestHandler_IdleTimeout_ReleasesResources(t *testing.T) {
+	const timeout = 60 * time.Millisecond
+	h, watcher, initCount := newTestHandler(t, timeout)
+
+	if err := h.ensureSession(context.Background()); err != nil {
+		t.Fatalf("ensureSession failed: %v", err)
+	}
+	if initCount.Load() != 1 {
+		t.Fatalf("initFn not called on first ensureSession")
+	}
+
+	// Wait for idle timer to fire (2× timeout for safety).
+	time.Sleep(timeout * 2)
+
+	h.initMu.Lock()
+	sessionNil := h.session == nil
+	h.initMu.Unlock()
+
+	if !sessionNil {
+		t.Error("session should be nil after idle timeout")
+	}
+	if !watcher.closed.Load() {
+		t.Error("watcher.Close() should have been called after idle timeout")
+	}
+}
+
+func TestHandler_IdleTimeout_ReinitOnNextCall(t *testing.T) {
+	const timeout = 60 * time.Millisecond
+	h, _, initCount := newTestHandler(t, timeout)
+
+	// First init.
+	if err := h.ensureSession(context.Background()); err != nil {
+		t.Fatalf("first ensureSession failed: %v", err)
+	}
+
+	// Wait for idle timeout.
+	time.Sleep(timeout * 2)
+
+	// Re-init on next call.
+	if err := h.ensureSession(context.Background()); err != nil {
+		t.Fatalf("second ensureSession failed: %v", err)
+	}
+
+	h.initMu.Lock()
+	sessionNil := h.session == nil
+	h.initMu.Unlock()
+
+	if sessionNil {
+		t.Error("session should be non-nil after re-initialization")
+	}
+	if got := initCount.Load(); got != 2 {
+		t.Errorf("initFn called %d times, want 2 (initial + re-init)", got)
+	}
+}
+
+func TestHandler_ResetIdleTimer_PostponesShutdown(t *testing.T) {
+	const timeout = 80 * time.Millisecond
+	h, watcher, _ := newTestHandler(t, timeout)
+
+	if err := h.ensureSession(context.Background()); err != nil {
+		t.Fatalf("ensureSession failed: %v", err)
+	}
+
+	// Reset the timer repeatedly just before it would fire.
+	for i := 0; i < 3; i++ {
+		time.Sleep(timeout / 2)
+		h.resetIdleTimer()
+	}
+
+	// Resources should still be alive.
+	if watcher.closed.Load() {
+		t.Error("watcher should not be closed while timer is being reset")
+	}
+	h.initMu.Lock()
+	if h.session == nil {
+		t.Error("session should still be alive while timer is being reset")
+	}
+	h.initMu.Unlock()
+
+	// Now stop resetting and wait for expiry.
+	time.Sleep(timeout * 2)
+
+	if !watcher.closed.Load() {
+		t.Error("watcher should be closed after timer expires without reset")
+	}
+}
+
+func TestConfig_IdleTimeoutDefault(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.IdleTimeout != "5m" {
+		t.Errorf("default IdleTimeout = %q, want \"5m\"", cfg.IdleTimeout)
+	}
+}
+
+func TestConfig_IdleTimeoutJSON(t *testing.T) {
+	for _, tc := range []struct {
+		json string
+		want time.Duration
+	}{
+		{`{"idle_timeout": "10s"}`, 10 * time.Second},
+		{`{"idle_timeout": "500ms"}`, 500 * time.Millisecond},
+		{`{"idle_timeout": "15m"}`, 15 * time.Minute},
+	} {
+		cfg, err := LoadConfig([]byte(tc.json))
+		if err != nil {
+			t.Fatalf("LoadConfig(%s) failed: %v", tc.json, err)
+		}
+		h := NewHandler(nil, WithConfig(cfg))
+		if h.idleTimeout != tc.want {
+			t.Errorf("json=%s: idleTimeout = %v, want %v", tc.json, h.idleTimeout, tc.want)
+		}
+	}
+}

--- a/gopls/mcpbridge/core/handlers.go
+++ b/gopls/mcpbridge/core/handlers.go
@@ -3,11 +3,14 @@ package core
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"golang.org/x/tools/gopls/internal/cache"
@@ -20,15 +23,29 @@ import (
 	"golang.org/x/tools/gopls/mcpbridge/api"
 )
 
+// InitFunc creates the gopls session, symbler, and file watcher on first use.
+// The returned io.Closer is the file watcher; may be nil if watching failed.
+type InitFunc func(ctx context.Context) (*cache.Session, Symbler, io.Closer, error)
+
 // Handler implements gopls-mcp MCP tools using gopls's existing APIs.
-// This bridges the MCP tool requests to gopls's session, snapshot, and analysis capabilities.
+// Resources are initialized lazily on first tool call and released after
+// idleTimeout of inactivity.
 type Handler struct {
+	// initFn creates gopls session + watcher on first tool call.
+	initFn      InitFunc
+	// config holds the gopls-mcp configuration (response limits, etc.)
+	config      *MCPConfig
+	idleTimeout time.Duration
+	// options holds gopls configuration for dynamic view creation (test mode).
+	options *settings.Options
+
+	// lazy-initialized resources, protected by initMu.
+	initMu  sync.Mutex
 	session *cache.Session
 	symbler Symbler
-	// options holds the gopls configuration options used for creating views.
-	options *settings.Options
-	// config holds the gopls-mcp configuration (response limits, etc.)
-	config *MCPConfig
+	watcher io.Closer
+	timer   *time.Timer
+
 	// allowDynamicViews enables creating new gopls views on-demand for e2e testing.
 	// When false (default), viewForDir returns an error if no existing view matches.
 	// When true (test mode), viewForDir creates a new view for the directory.
@@ -48,6 +65,13 @@ type HandlerOption func(*Handler)
 func WithConfig(config *MCPConfig) HandlerOption {
 	return func(h *Handler) {
 		h.config = config
+	}
+}
+
+// WithOptions sets gopls options used for dynamic view creation (test mode).
+func WithOptions(opts *settings.Options) HandlerOption {
+	return func(h *Handler) {
+		h.options = opts
 	}
 }
 
@@ -74,31 +98,85 @@ type Symbler interface {
 	Symbol(ctx context.Context, params *protocol.WorkspaceSymbolParams) ([]protocol.SymbolInformation, error)
 }
 
-// NewHandler creates a new Handler backed by gopls's session and LSP server.
-// Based on: gopls/internal/mcp/mcp.go handler struct (line 31-34)
-//
-// Note: This does NOT eagerly populate the cache. The gopls snapshot uses
-// lazy loading, where packages are loaded on-demand when tool handlers
-// call methods like WorkspaceMetadata(), LoadMetadataGraph(), etc.
-// These methods internally call awaitLoaded() which triggers reloadWorkspace().
-func NewHandler(session *cache.Session, symbler Symbler, opts ...HandlerOption) *Handler {
+// NewHandler creates a new Handler that initializes gopls lazily on first tool call.
+// Resources are released after idleTimeout (configured via MCPConfig.IdleTimeoutMinutes)
+// of inactivity, and re-initialized on the next call.
+func NewHandler(initFn InitFunc, opts ...HandlerOption) *Handler {
 	h := &Handler{
-		session:           session,
-		symbler:           symbler,
-		options:           settings.DefaultOptions(), // Default gopls options
-		config:            DefaultConfig(),           // Default gopls-mcp config
-		allowDynamicViews: false,                     // Production mode: no dynamic views
-		dynamicViews:      make(map[string]func()),
+		initFn:       initFn,
+		options:      settings.DefaultOptions(),
+		config:       DefaultConfig(),
+		dynamicViews: make(map[string]func()),
 	}
 	for _, opt := range opts {
 		opt(h)
 	}
+	if d, err := time.ParseDuration(h.config.IdleTimeout); err == nil && d > 0 {
+		h.idleTimeout = d
+	} else {
+		h.idleTimeout = 5 * time.Minute
+	}
 	return h
+}
+
+// ensureSession initializes the gopls session if not already done.
+// Safe to call concurrently; only one goroutine performs initialization.
+func (h *Handler) ensureSession(ctx context.Context) error {
+	h.initMu.Lock()
+	defer h.initMu.Unlock()
+	if h.session != nil {
+		return nil
+	}
+	// Use background context: initialization must not be cancelled by the
+	// request context, as it is shared across all subsequent requests.
+	session, symbler, watcher, err := h.initFn(context.Background())
+	if err != nil {
+		return fmt.Errorf("gopls initialization failed: %w", err)
+	}
+	h.session = session
+	h.symbler = symbler
+	h.watcher = watcher
+	h.timer = time.AfterFunc(h.idleTimeout, h.shutdownResources)
+	log.Printf("[gopls-mcp] Session initialized (idle timeout: %v)", h.idleTimeout)
+	return nil
+}
+
+// resetIdleTimer postpones the idle shutdown by another idleTimeout duration.
+// Called after each successful tool invocation.
+func (h *Handler) resetIdleTimer() {
+	h.initMu.Lock()
+	defer h.initMu.Unlock()
+	if h.timer != nil {
+		h.timer.Reset(h.idleTimeout)
+	}
+}
+
+// shutdownResources releases all gopls resources: file watcher inotify FDs,
+// gopls goroutines (parse cache, import timers), and snapshot memory.
+// Called by the idle timer; safe to call multiple times.
+func (h *Handler) shutdownResources() {
+	h.initMu.Lock()
+	defer h.initMu.Unlock()
+	if h.watcher != nil {
+		h.watcher.Close()
+		h.watcher = nil
+	}
+	if h.session != nil {
+		// Shutdown blocks until all outstanding snapshots are released.
+		h.session.Shutdown(context.Background())
+		h.session = nil
+		h.symbler = nil
+	}
+	h.timer = nil
+	log.Printf("[gopls-mcp] All resources released (idle timeout reached)")
 }
 
 // snapshot returns the best default snapshot for workspace queries.
 // Based on: gopls/internal/mcp/mcp.go snapshot() method (line 316-322)
 func (h *Handler) snapshot() (*cache.Snapshot, func(), error) {
+	if h.session == nil {
+		return nil, nil, fmt.Errorf("no active session")
+	}
 	views := h.session.Views()
 	if len(views) == 0 {
 		return nil, nil, fmt.Errorf("no active views")
@@ -183,6 +261,9 @@ func (h *Handler) viewForDir(dir string) (*cache.View, error) {
 func (h *Handler) getView(dir string) (*cache.View, error) {
 	if dir != "" {
 		return h.viewForDir(dir)
+	}
+	if h.session == nil {
+		return nil, fmt.Errorf("no active session")
 	}
 	views := h.session.Views()
 	if len(views) == 0 {

--- a/gopls/mcpbridge/core/tool.go
+++ b/gopls/mcpbridge/core/tool.go
@@ -39,8 +39,14 @@ func (t GenericTool[In, Out]) Register(server *mcp.Server, handler *Handler) {
 		maxBytes = defaultMaxResponseBytes
 	}
 
-	// Create a wrapper function that applies response limits
+	// Create a wrapper function that applies lazy init and response limits
 	wrapped := func(ctx context.Context, req *mcp.CallToolRequest, input In) (*mcp.CallToolResult, Out, error) {
+		var zero Out
+		if err := handler.ensureSession(ctx); err != nil {
+			return nil, zero, err
+		}
+		defer handler.resetIdleTimer()
+
 		result, output, err := t.Handler(ctx, handler, req, input)
 		if err != nil {
 			return result, output, err

--- a/gopls/mcpbridge/pkg/execute.go
+++ b/gopls/mcpbridge/pkg/execute.go
@@ -62,6 +62,9 @@ var (
 	// directoryFiltersFlag allows setting gopls directoryFilters via CLI flag.
 	// Filters use the same syntax as gopls directoryFilters (e.g. "-**/node_modules,-vendor").
 	directoryFiltersFlag = flag.String("directory-filters", "", "Comma-separated directory filters (e.g. \"-**/node_modules,-vendor\")")
+	// idleTimeoutFlag sets the duration of inactivity before gopls resources are released.
+	// Accepts Go duration strings: "5m", "30s", "500ms". Overrides the config file value.
+	idleTimeoutFlag = flag.String("idle-timeout", "", "Inactivity duration before releasing gopls resources (e.g. \"5m\", \"30s\", default: 5m)")
 )
 
 const (
@@ -156,58 +159,22 @@ func Execute() {
 		log.Printf("[gopls-mcp] Directory filters from CLI: %v", filters)
 	}
 
+	// Merge CLI idle-timeout into config (overrides config file value)
+	if *idleTimeoutFlag != "" {
+		config.IdleTimeout = *idleTimeoutFlag
+	}
+
 	// Override workdir from config if set
 	if config.Workdir != "" {
 		projectDir = config.Workdir
 		log.Printf("[gopls-mcp] Using workdir from config: %s", projectDir)
 	}
 
-	// Create gopls cache
-	ctx := context.Background()
-	goplsCache := cache.New(nil)
-	session := cache.NewSession(ctx, goplsCache)
-
-	// Initialize gopls options (REQUIRED for view creation)
-	// Start with defaults and apply user configuration
+	// Build gopls options from config (needed for watcher filters and view creation).
 	options := settings.DefaultOptions()
-
-	// Apply gopls configuration from MCP config
-	// This allows users to set native gopls options like analyses, buildFlags, etc.
 	if err := config.ApplyGoplsOptions(options); err != nil {
 		log.Printf("[gopls-mcp] Warning: Failed to apply some gopls options: %v", err)
-		// Continue anyway - partial configuration is better than failure
-	} else {
-		log.Printf("[gopls-mcp] Gopls options applied successfully")
 	}
-
-	// Fetch Go environment for the working directory (REQUIRED for view creation)
-	// This loads GOROOT, GOPATH, GOVERSION, and other critical environment info
-	dirURI := protocol.URIFromPath(projectDir)
-	goEnv, err := cache.FetchGoEnv(ctx, dirURI, options)
-	if err != nil {
-		log.Fatalf("[gopls-mcp] Failed to load Go env: %v", err)
-	}
-
-	// Create a view for the working directory with proper initialization
-	// This enables gopls to analyze the Go project
-	folder := &cache.Folder{
-		Dir:     dirURI,
-		Options: options,
-		Env:     *goEnv,
-	}
-	view, _, releaseView, err := session.NewView(ctx, folder)
-	if err != nil {
-		log.Fatalf("[gopls-mcp] Failed to create view for %s: %v", projectDir, err)
-	}
-	defer releaseView()
-
-	log.Printf("[gopls-mcp] Created view for %s (type: %v)", projectDir, view.Type())
-	releaseView() // Release the initial snapshot since we won't use it
-
-	// Create a minimal LSP server stub that implements the methods we need
-	// The gopls-mcp handlers use the Symbol method for search
-	// The watcher uses DidChangeWatchedFiles to notify gopls of file changes
-	lspServer := &minimalServer{session: session}
 
 	// Build directory skip function from directoryFilters so the file
 	// watcher excludes the same directories that gopls analysis ignores
@@ -217,28 +184,50 @@ func Execute() {
 		watcherOpts = append(watcherOpts, makeDirectoryFilterSkipFunc(filters, projectDir))
 	}
 
-	// Start file change watcher
-	// This keeps the gopls cache up-to-date when files are edited
-	var fileWatcher *watcher.Watcher
-	fileWatcher, err = watcher.New(lspServer, projectDir, watcherOpts...)
-	if err != nil {
-		log.Printf("[gopls-mcp] Failed to start file watcher: %v", err)
-		// Continue anyway - tools will work but file changes won't be detected
-	} else {
-		defer fileWatcher.Close()
-		log.Printf("[gopls-mcp] File watcher started for %s", projectDir)
+	// initFn creates the gopls session, file watcher, and LSP server on first
+	// tool call (lazy init). Resources are released by shutdownResources after
+	// the idle timeout and recreated here on the next call.
+	initFn := func(ctx context.Context) (*cache.Session, core.Symbler, io.Closer, error) {
+		goplsCache := cache.New(nil)
+		session := cache.NewSession(ctx, goplsCache)
+
+		dirURI := protocol.URIFromPath(projectDir)
+		goEnv, err := cache.FetchGoEnv(ctx, dirURI, options)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to load Go env: %w", err)
+		}
+
+		folder := &cache.Folder{
+			Dir:     dirURI,
+			Options: options,
+			Env:     *goEnv,
+		}
+		_, _, releaseView, err := session.NewView(ctx, folder)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to create view for %s: %w", projectDir, err)
+		}
+		releaseView()
+
+		lspServer := &minimalServer{session: session}
+
+		fw, err := watcher.New(lspServer, projectDir, watcherOpts...)
+		if err != nil {
+			log.Printf("[gopls-mcp] Failed to start file watcher: %v (file changes won't be detected)", err)
+			return session, lspServer, nil, nil
+		}
+		log.Printf("[gopls-mcp] Initialized gopls for %s", projectDir)
+		return session, lspServer, fw, nil
 	}
 
-	// Create gopls-mcp handler backed by gopls session
-	// Pass the config to enable response limits
+	// Create gopls-mcp handler with lazy init and idle timeout.
 	var handlerOpts []core.HandlerOption
 	handlerOpts = append(handlerOpts, core.WithConfig(config))
-	// Check environment variable for dynamic view creation (test-only)
+	handlerOpts = append(handlerOpts, core.WithOptions(options))
 	if os.Getenv(allowDynamicViewsEnv) == "true" || os.Getenv(allowDynamicViewsEnv) == "1" {
 		log.Printf("[gopls-mcp] Dynamic views enabled via %s (TEST-ONLY)", allowDynamicViewsEnv)
 		handlerOpts = append(handlerOpts, core.WithDynamicViews(true))
 	}
-	coreHandler := core.NewHandler(session, lspServer, handlerOpts...)
+	coreHandler := core.NewHandler(initFn, handlerOpts...)
 
 	// Create MCP server and register all gopls-mcp tools
 	server := mcp.NewServer(&mcp.Implementation{Name: mcpName, Version: version}, nil)
@@ -267,6 +256,7 @@ func Execute() {
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	// Run server in a goroutine so we can handle signals
+	ctx := context.Background()
 	serverErrCh := make(chan error, 1)
 	go func() {
 		serverErrCh <- server.Run(ctx, &mcp.StdioTransport{})


### PR DESCRIPTION
Defer gopls session initialization to the first tool call and release all resources after a configurable idle period (default `5m`).

- **Lazy init**: MCP server starts instantly; gopls session/view/watcher are created on the first tool call.
- **Idle timeout**: after inactivity, `session.Shutdown()` + `watcher.Close()` free all resources. Session re-initializes transparently on the next call.
- **Config**: `-idle-timeout 30s` flag or `{"idle_timeout": "30s"}` in config file (Go duration string).

Fixes resource exhaustion when multiple Claude Code agent sessions run in parallel, each holding a full gopls workspace in memory.