### PR TITLE
feature: deliver gopls-mcp as a Claude Code / Codex plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "gopls-mcp-marketplace",
+  "owner": {
+    "name": "xieyuschen",
+    "email": "xieyuschen@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "gopls-mcp",
+      "description": "Semantic Go code analysis using gopls — type-aware definitions, references, implementations, and call hierarchy.",
+      "source": "./plugin"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ gopls/mcpbridge/test/benchmark/benchmark_results.json
 gopls/mcpbridge/test/benchmark/RESULTS.md
 gopls/mcpbridge/test/benchmark/RESULTS_COMPACT.md
 *.test
-gopls-mcp
+/gopls-mcp
 gopls/mcpbridge/test/e2e/testdata/golden
 gopls/mcpbridge/test/integration/testdata/golden/
 .mcpregistry_github_token

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     ldflags:
       - -s -w -X golang.org/x/tools/gopls/mcpbridge/pkg.version={{.Tag}}
     main: .

--- a/README.md
+++ b/README.md
@@ -2,16 +2,48 @@
 
 Give your AI Agent the compiler's brain, not a text searcher.
 
-Documentation: https://gopls-mcp.org.
+Documentation: https://gopls-mcp.org
 
-gopls-mcp delivers lightning-fast, language-level analysis directly to your LLM. 
+gopls-mcp delivers lightning-fast, language-level analysis directly to your LLM.
 Unlike standard retrieval tools that flood the context window with irrelevant text, this tool performs surgical code navigation.
 
 By providing only the scientifically accurate definitions and references, it maximizes your model's attention span and keeps the reasoning chain pure. Zero noise, absolute structural accuracy, and instant response times.
 
+## Install
+
+### Claude Code (plugin — recommended)
+
+```
+/plugin marketplace add https://github.com/xieyuschen/gopls-mcp.git
+/plugin install gopls-mcp
+```
+
+The plugin automatically installs the binary and injects the routing skill — no manual setup required.
+
+### Codex (plugin — recommended)
+
+```bash
+codex plugin marketplace add https://github.com/xieyuschen/gopls-mcp.git
+codex plugin add gopls-mcp
+```
+
+### Manual install (all clients)
+
+**Linux / macOS:**
+```bash
+curl -sSL https://gopls-mcp.org/install.sh | bash
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://gopls-mcp.org/install.ps1 | iex
+```
+
+Then follow the per-client setup at https://gopls-mcp.org/quick-start.
+
 ## Contribute
 
 The project is actively developing, and feel free to raise PRs or issues if you find anything to improve.
-AI generated code will also be accepted but do remember to narrow the change to a specfic feature for reviewer to quickly review them.
+AI generated code will also be accepted but do remember to narrow the change to a specific feature for reviewer to quickly review them.
 
-*Disclaimer*: gopls-mcp is a fork of [gopls](https://tip.golang.org/gopls/) and is a community-driven project. It is not an official Go team product and is not affiliated with or endorsed by Google LLC. This project is licensed under the same BSD license as its  [upstream](https://go.googlesource.com/tools) source.
+*Disclaimer*: gopls-mcp is a fork of [gopls](https://tip.golang.org/gopls/) and is a community-driven project. It is not an official Go team product and is not affiliated with or endorsed by Google LLC. This project is licensed under the same BSD license as its [upstream](https://go.googlesource.com/tools) source.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "gopls-mcp",
+  "version": "1.0.5",
+  "description": "Semantic Go code analysis using gopls — type-aware definitions, references, implementations, and call hierarchy.",
+  "author": {
+    "name": "xieyuschen",
+    "email": "xieyuschen@gmail.com"
+  },
+  "homepage": "https://gopls-mcp.org",
+  "repository": "https://github.com/xieyuschen/gopls-mcp.git",
+  "license": "BSD-3-Clause",
+  "keywords": ["go", "golang", "gopls", "mcp", "semantic", "code-analysis"],
+  "skills": "./skills/",
+  "mcpServers": {
+    "gopls-mcp": {
+      "type": "stdio",
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run.sh"
+    }
+  }
+}

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "gopls-mcp",
+  "version": "1.0.5",
+  "description": "Semantic Go code analysis using gopls — type-aware definitions, references, implementations, and call hierarchy.",
+  "author": {
+    "name": "xieyuschen",
+    "email": "xieyuschen@gmail.com"
+  },
+  "repository": "https://github.com/xieyuschen/gopls-mcp.git",
+  "license": "BSD-3-Clause",
+  "keywords": ["go", "golang", "gopls", "mcp", "semantic", "code-analysis"],
+  "skills": "./skills/",
+  "hooks": "./hooks/codex-hooks.json",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "gopls-mcp",
+    "shortDescription": "Semantic Go code analysis",
+    "longDescription": "gopls-mcp connects Codex to the Go language server for type-aware definitions, references, implementations, call hierarchy, dependency graphs, and rename previews.",
+    "developerName": "xieyuschen",
+    "category": "Development",
+    "capabilities": ["Read"]
+  }
+}

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "gopls-mcp": {
+      "type": "stdio",
+      "command": "./scripts/run.sh",
+      "cwd": "."
+    }
+  }
+}

--- a/plugin/hooks/codex-hooks.json
+++ b/plugin/hooks/codex-hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/on_session_start.sh",
+            "statusMessage": "Loading gopls-mcp context..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/on_session_start.sh",
+            "statusMessage": "Loading gopls-mcp context..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin/scripts/on_session_start.sh
+++ b/plugin/scripts/on_session_start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# SessionStart hook for gopls-mcp plugin.
+#
+# Injects a brief activation notice into Claude's context and reloads skills
+# so the gopls-mcp routing skill is guaranteed to be active. The full routing
+# protocol (which tools to use, constraints, error handling) lives in the
+# gopls-mcp SKILL.md; this hook only supplies the one-liner reminder that
+# keeps the tool top-of-mind without duplicating the skill content.
+
+set -euo pipefail
+
+printf '%s' '{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "gopls-mcp is active. Use go_definition, go_implementation, go_symbol_references, go_get_call_hierarchy, go_get_dependency_graph, go_dryrun_rename_symbol for semantic Go analysis — these are type-aware and cannot be replaced by grep. See the gopls-mcp skill for the full routing protocol.",
+    "reloadSkills": true
+  }
+}'

--- a/plugin/scripts/run.sh
+++ b/plugin/scripts/run.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# gopls-mcp plugin launcher
+#
+# Design rationale — why this script exists:
+#
+#   The Claude Code / Codex plugin system has no PostInstall or PostUpdate
+#   lifecycle hook. There is therefore no dedicated moment to download or
+#   upgrade the gopls-mcp binary after a plugin install or update. The only
+#   reliable hook we have is the MCP server's own startup, so this script
+#   acts as both installer and launcher: it checks whether the binary is
+#   present and at the right version, downloads from GitHub Releases if not,
+#   then execs the binary. On a warm path the check is a fast string compare
+#   and adds no perceptible latency.
+#
+# Update mechanism — how version upgrades propagate:
+#
+#   EXPECTED_VERSION is hardcoded here. When a new gopls-mcp release is cut,
+#   this value is bumped and the change is committed to the plugin repo.
+#   Running `/plugin update` performs a git pull of the plugin repo, which
+#   delivers the new EXPECTED_VERSION. On the next session start this script
+#   detects that the installed binary (`gopls-mcp -version`) does not match
+#   EXPECTED_VERSION and downloads the correct release tarball.
+#
+# Binary location — why $HOME/.local/bin:
+#
+#   The binary lives in the user's own PATH directory, not inside
+#   ${CLAUDE_PLUGIN_ROOT}. The plugin root is an internal directory managed
+#   by Claude Code / Codex whose layout and lifetime are implementation
+#   details we should not depend on. $HOME/.local/bin is a stable,
+#   user-owned location that survives plugin reinstalls and host tool updates.
+
+set -euo pipefail
+
+EXPECTED_VERSION="1.0.5"
+BINARY="${HOME}/.local/bin/gopls-mcp"
+REPO="xieyuschen/gopls-mcp"
+
+needs_install() {
+    [ ! -f "${BINARY}" ] && return 0
+    local current
+    current=$("${BINARY}" -version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
+    [ "${current}" != "${EXPECTED_VERSION}" ]
+}
+
+install_binary() {
+    local os arch filename url tmpdir
+
+    case "$(uname -s)" in
+        Linux*)  os=linux ;;
+        Darwin*) os=darwin ;;
+        *)       echo "[gopls-mcp] Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+    esac
+
+    case "$(uname -m)" in
+        x86_64*)         arch=amd64 ;;
+        aarch64*|arm64*) arch=arm64 ;;
+        *)               echo "[gopls-mcp] Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+    esac
+
+    filename="gopls-mcp_${EXPECTED_VERSION}_${os}_${arch}.tar.gz"
+    url="https://github.com/${REPO}/releases/download/v${EXPECTED_VERSION}/${filename}"
+
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "${tmpdir}"' EXIT
+
+    echo "[gopls-mcp] Downloading v${EXPECTED_VERSION} (${os}/${arch})..." >&2
+
+    if ! curl -fsSL "${url}" -o "${tmpdir}/${filename}"; then
+        echo "[gopls-mcp] Failed to download from ${url}" >&2
+        exit 1
+    fi
+
+    mkdir -p "${HOME}/.local/bin"
+    tar -xzf "${tmpdir}/${filename}" -C "${tmpdir}" gopls-mcp
+    mv "${tmpdir}/gopls-mcp" "${BINARY}"
+    chmod +x "${BINARY}"
+
+    echo "[gopls-mcp] Installed v${EXPECTED_VERSION} to ${BINARY}" >&2
+}
+
+if needs_install; then
+    install_binary
+fi
+
+exec "${BINARY}" "$@"

--- a/plugin/skills/gopls-mcp/SKILL.md
+++ b/plugin/skills/gopls-mcp/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: gopls-mcp
+description: >
+  Semantic Go code analysis using gopls — type-aware definitions, references, implementations,
+  call hierarchy, dependency graphs, and rename previews. Use these tools for semantic Go tasks;
+  never fall back to grep — gopls sees types, scopes, and interfaces that text search misses.
+metadata:
+  category: go-code-analysis
+  requires:
+    mcp_servers: ["gopls-mcp"]
+---
+
+# Project Instructions for AI Code Assistant with gopls-mcp
+
+## What gopls-mcp does (and what it doesn't)
+
+gopls-mcp is **strictly a semantic Go layer** built on top of gopls's type
+checker. It exposes six tools — that's the whole surface area:
+
+| Task | Tool |
+|------|------|
+| Jump to definition | `go_definition` |
+| Find interface implementations | `go_implementation` |
+| Find symbol references | `go_symbol_references` |
+| Trace call relationships | `go_get_call_hierarchy` |
+| Analyze package dependencies | `go_get_dependency_graph` |
+| Preview a symbol rename | `go_dryrun_rename_symbol` |
+
+These cannot be replaced by `Grep` + `Read`, because Go's type system makes
+interfaces, scopes, and identity invisible to text search.
+
+For *anything else* — listing packages, reading `go.mod`, searching symbol
+names, running `go build`, scanning files — use your native tools (`Glob`,
+`Grep`, `Read`, `Bash`). They are already optimal for those jobs, so we
+deliberately don't ship duplicates.
+
+## Routing rules
+
+1. **Semantic relationship?** Use the table above. Never fall back to grep —
+   you'd miss interface satisfaction, shadowing, cross-package identity.
+2. **Text search / file listing / build / mod?** Use `Grep` / `Glob` /
+   `Read` / `Bash`. There is no gopls-mcp tool for these.
+3. **Output**: present `file:line` locations, signatures, and docs cleanly.
+   Never dump raw JSON.
+
+## Tool-specific constraints
+
+* **`go_implementation`**: Interfaces and types only. **Not** for functions.
+* **General locator parameters**:
+  * `symbol_name`: bare identifier, no package prefix
+    (`"Start"`, not `"Server.Start"`).
+  * `context_file`: an absolute path to the file you are currently reading
+    or where the symbol appears. The resolver uses this for scope and
+    import disambiguation.
+
+## Error handling
+
+If a semantic tool returns nothing, do **not** silently fall back to grep:
+
+1. Verify the symbol name is spelled exactly as in source (case-sensitive).
+2. Confirm `context_file` is correct and inside a Go module.
+3. For `go_implementation`, check that `parent_scope` points at the
+   interface, not the concrete type.
+
+Only after these checks fail should you fall back to manual `Read` of the
+relevant file — and only as diagnosis, not as a substitute capability.

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.xieyuschen/gopls-mcp",
   "description": "Semantic code analysis for Go using gopls - language-aware navigation, definitions, references",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "xieyuschen",
   "license": "BSD-3-Clause",
   "repository": {

--- a/site/src/content/docs/quick-start/claude-code.md
+++ b/site/src/content/docs/quick-start/claude-code.md
@@ -8,52 +8,63 @@ Configure gopls-mcp with Claude Code.
 
 ---
 
-### Setup gopls-mcp for Your Project
+## Install via Plugin
 
-Ensure [claude code](https://code.claude.com/docs/en/overview) is installed, and run command below to add mcp server into claude code.
+```
+/plugin marketplace add https://github.com/xieyuschen/gopls-mcp.git
+/plugin install gopls-mcp
+```
+
+That's it. The plugin handles everything automatically:
+
+- Downloads and installs the `gopls-mcp` binary to `~/.local/bin/`
+- Registers the MCP server
+- Injects the routing skill (which tools to use and when)
+- Adds a session-start hook that activates the skill each session
+
+Running `/plugin update gopls-mcp` upgrades the binary and rules together.
+
+### Verify
+
+```
+/mcp
+```
+
+You should see `gopls-mcp · ✔ connected`.
+
+---
+
+## Manual Install (without plugin)
+
+Use this only if you cannot use the plugin system.
+
+### 1. Install binary
+
+**Linux / macOS:**
+```bash
+curl -sSL https://gopls-mcp.org/install.sh | bash
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://gopls-mcp.org/install.ps1 | iex
+```
+
+### 2. Register the MCP server
 
 ```bash
 claude mcp add gopls-mcp -- gopls-mcp
 ```
 
-You will see the similar log below if succeed.
-
-```
-Added stdio MCP server gopls-mcp with command: gopls-mcp to local config
-File modified: /home/xieyuschen/.claude.json
-[project: /home/xieyuschen/codespace/gopls-mcproot]
-```
-
----
-
-### Configure Project Instructions (CLAUDE.md)
-
-Claude needs specific instructions to know when to use the semantic tools. Run this command in your project root to add the rules (safe for both new and existing projects):
-The script creates the file if it doesn't exist; preserves content if it does)
+### 3. Add routing rules to CLAUDE.md
 
 ```bash
 curl -sL https://gopls-mcp.org/gopls-mcp.prompt >> CLAUDE.md
 ```
 
-### Verify gopls-mcp
-
-Inside claude code, run `/mcp` command to verify `gopls-mcp` is availble.
+### 4. Verify
 
 ```
-(claude)> /mcp
+/mcp
+❯ gopls-mcp · ✔ connected
 ```
-
-If the tool is successfully added, you will see similiar output below:
-
-```
- Manage MCP servers
- 1 server
-
-   Local MCPs (/home/xieyuschen/.claude.json
-   [project: /home/xieyuschen/codespace/gopls-mcproot])
- ❯ gopls-mcp · ✔ connected
-
- https://code.claude.com/docs/en/mcp for help
-```
-
----

--- a/site/src/content/docs/quick-start/codex.md
+++ b/site/src/content/docs/quick-start/codex.md
@@ -8,54 +8,63 @@ Configure gopls-mcp with Codex CLI.
 
 ---
 
-### Setup gopls-mcp for Your Project
+## Install via Plugin
 
-Ensure [codex-cli](https://github.com/openai/codex) is installed, and run command below to add mcp server.
+```bash
+codex plugin marketplace add https://github.com/xieyuschen/gopls-mcp.git
+codex plugin add gopls-mcp
+```
+
+That's it. The plugin handles everything automatically:
+
+- Downloads and installs the `gopls-mcp` binary to `~/.local/bin/`
+- Registers the MCP server
+- Injects the routing skill (which tools to use and when)
+- Adds a session-start hook that activates the skill each session
+
+Running `codex plugin update gopls-mcp` upgrades the binary and rules together.
+
+### Verify
+
+```bash
+codex mcp list
+```
+
+You should see `gopls-mcp` with status `enabled`.
+
+---
+
+## Manual Install (without plugin)
+
+Use this only if you cannot use the plugin system.
+
+### 1. Install binary
+
+**Linux / macOS:**
+```bash
+curl -sSL https://gopls-mcp.org/install.sh | bash
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://gopls-mcp.org/install.ps1 | iex
+```
+
+### 2. Register the MCP server
 
 ```bash
 codex mcp add gopls-mcp -- gopls-mcp
 ```
 
-You will see the similar log below if succeed.
-
-```
-Added global MCP server 'gopls-mcp'.
-```
-
----
-
-### Configure Project Instructions (AGENTS.md)
-
-Codex needs specific instructions to know when to use the semantic tools. Run this command in your project root to add the rules:
+### 3. Add routing rules to AGENTS.md
 
 ```bash
 curl -sL https://gopls-mcp.org/gopls-mcp.prompt >> AGENTS.md
 ```
 
-### Verify gopls-mcp
-
-Inside codex-cli, run mcp list command to verify `gopls-mcp` is available.
-
-```
-$ codex mcp list
-Name       Command    Args  Env  Cwd  Status   Auth       
-gopls-mcp  gopls-mcp  -     -    -    enabled  Unsupported
-```
-
-If the tool is successfully added, you will see gopls-mcp in the server list.
-
----
-
-Enter `codex` and run command `/mcp`:
+### 4. Verify
 
 ```
 /mcp
-
-🔌  MCP Tools
-
-  • gopls-mcp
-    • Status: enabled
-    • Auth: Unsupported
-    • Command: gopls-mcp
-    ...
+• gopls-mcp · enabled
 ```

--- a/site/src/content/docs/quick-start/index.md
+++ b/site/src/content/docs/quick-start/index.md
@@ -8,27 +8,13 @@ sidebar:
 
 ### Installation
 
-**Linux / macOS:**
-```bash
-curl -sSL https://gopls-mcp.org/install.sh | bash
-```
+Install via the plugin system for your agent — it handles the binary, MCP registration, routing skill, and session hooks automatically:
 
-**Windows (PowerShell):**
-```powershell
-irm https://gopls-mcp.org/install.ps1 | iex
-```
-
----
-
-### Code Agent Setup
-
-Configure gopls-mcp with your code agent:
-
-| | |
-|:---:|:---|
-| <img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/dark/claude-color.png" alt="Claude Code" width="32" height="32" class="light:sl-hidden"><img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/light/claude-color.png" alt="Claude Code" width="32" height="32" class="dark:sl-hidden"> | [Claude Code](./claude-code) |
-| <img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/dark/gemini-color.png" alt="Gemini CLI" width="32" height="32" class="light:sl-hidden"><img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/light/gemini-color.png" alt="Gemini CLI" width="32" height="32" class="dark:sl-hidden"> | [Gemini CLI](./gemini-cli) |
-| <img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/dark/openai.png" alt="Codex CLI" width="32" height="32" class="light:sl-hidden"><img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/light/openai.png" alt="Codex CLI" width="32" height="32" class="dark:sl-hidden"> | [Codex CLI](./codex) |
-| <img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/dark/cursor.png" alt="Cursor" width="32" height="32" class="light:sl-hidden"><img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/light/cursor.png" alt="Cursor" width="32" height="32" class="dark:sl-hidden"> | [Cursor](./cursor) |
+| | | Plugin install |
+|:---:|:---|:---|
+| <img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/dark/claude-color.png" alt="Claude Code" width="32" height="32" class="light:sl-hidden"><img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/light/claude-color.png" alt="Claude Code" width="32" height="32" class="dark:sl-hidden"> | [Claude Code](./claude-code) | `/plugin marketplace add https://github.com/xieyuschen/gopls-mcp.git` then `/plugin install gopls-mcp` |
+| <img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/dark/openai.png" alt="Codex CLI" width="32" height="32" class="light:sl-hidden"><img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/light/openai.png" alt="Codex CLI" width="32" height="32" class="dark:sl-hidden"> | [Codex CLI](./codex) | `codex plugin marketplace add https://github.com/xieyuschen/gopls-mcp.git` then `codex plugin add gopls-mcp` |
+| <img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/dark/gemini-color.png" alt="Gemini CLI" width="32" height="32" class="light:sl-hidden"><img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/light/gemini-color.png" alt="Gemini CLI" width="32" height="32" class="dark:sl-hidden"> | [Gemini CLI](./gemini-cli) | Manual install — see guide |
+| <img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/dark/cursor.png" alt="Cursor" width="32" height="32" class="light:sl-hidden"><img src="https://cdn.jsdelivr.net/gh/lobehub/lobe-icons@latest/packages/static-png/light/cursor.png" alt="Cursor" width="32" height="32" class="dark:sl-hidden"> | [Cursor](./cursor) | Manual install — see guide |
 
 ---


### PR DESCRIPTION
Adds a plugin structure so users can install gopls-mcp with two commands:

  /plugin marketplace add https://github.com/xieyuschen/gopls-mcp.git
  /plugin install gopls-mcp

The plugin bundles three components:

Binary installer (plugin/scripts/run.sh)
  The plugin system has no PostInstall/PostUpdate hook, so run.sh acts as both
  installer and launcher. On each MCP server startup it compares the installed
  binary version (gopls-mcp -version) against EXPECTED_VERSION embedded in the
  script. If they differ it downloads the correct release tarball from GitHub
  Releases, then execs the binary. This avoids re-downloading on every startup
  while propagating upgrades automatically when /plugin update bumps
  EXPECTED_VERSION via git pull. The binary is stored in $HOME/.local/bin to
  avoid depending on Claude Code / Codex internal directory layout.

Routing skill (plugin/skills/gopls-mcp/SKILL.md)
  Full routing protocol injected into Claude's context on install: which tools
  to use for semantic Go analysis, constraints, and error handling.

SessionStart hook (plugin/hooks/hooks.json + on_session_start.sh)
  Injects a brief activation notice and sets reloadSkills:true at the start of
  every session, ensuring the routing skill stays active without duplicating its
  content. Claude Code auto-loads hooks/hooks.json so it is not referenced in
  the manifest; codex-plugin references codex-hooks.json explicitly.

Also adds arm64 to .goreleaser.yaml and updates README and quick-start docs so the plugin path is the recommended install for Claude Code and Codex, with the old manual (curl + mcp add + CLAUDE.md) retained only as a fallback.